### PR TITLE
pass down RichQuery

### DIFF
--- a/db/migrations/postgres/000009_allow_null_transaction_data.down.sql
+++ b/db/migrations/postgres/000009_allow_null_transaction_data.down.sql
@@ -1,0 +1,1 @@
+-- No down migration for this one

--- a/db/migrations/postgres/000009_allow_null_transaction_data.up.sql
+++ b/db/migrations/postgres/000009_allow_null_transaction_data.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE transactions ALTER COLUMN tx_data DROP NOT NULL;
+
+COMMIT;

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/golang-lru/v2 v2.0.3
-	github.com/hyperledger/firefly-common v1.2.14-0.20230611031852-a7e8f8ab394c
+	github.com/hyperledger/firefly-common v1.2.14-0.20230624115424-95f92b67f626
 	github.com/lib/pq v1.10.9
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/prometheus/client_golang v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/hyperledger/firefly-common v1.2.14-0.20230611031852-a7e8f8ab394c h1:p2lhzIaS5pYmNJYeq2hu9KxN+jrOOtuj7uokh2HWe84=
-github.com/hyperledger/firefly-common v1.2.14-0.20230611031852-a7e8f8ab394c/go.mod h1:17lOH4YufiPy82LpKm8fPa/YXJ0pUyq01zK1CmklJwM=
+github.com/hyperledger/firefly-common v1.2.14-0.20230624115424-95f92b67f626 h1:kEwDvahd1BVg2aOmFcubKa9dKzWawGjXSevmnQJEck0=
+github.com/hyperledger/firefly-common v1.2.14-0.20230624115424-95f92b67f626/go.mod h1:17lOH4YufiPy82LpKm8fPa/YXJ0pUyq01zK1CmklJwM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/pkg/txhandler/txhandler.go
+++ b/pkg/txhandler/txhandler.go
@@ -27,6 +27,7 @@ import (
 
 type TransactionPersistence interface {
 	persistence.TransactionPersistence
+	RichQuery() persistence.RichQuery
 }
 
 type TransactionHistoryPersistence interface {


### PR DESCRIPTION
Pass through RichQuery in tx handler persistence interface 

also picks up https://github.com/hyperledger/firefly-common/pull/81 support for groupby query

also allowed tx_data to be null for transfer txs